### PR TITLE
Fixed typo in error-driver-stack-overflow.md

### DIFF
--- a/docs/details/error-driver-stack-overflow.md
+++ b/docs/details/error-driver-stack-overflow.md
@@ -1,4 +1,4 @@
-#Driver ran out of memory
+#Driver stack overflow
 
 Note that it is very rare to run into this error. You may see this error when you are using too many filters(in your sql/dataframe/dataset). Workaround is to increase spark driver JVM stack size by setting below config to something higher than the default
 


### PR DESCRIPTION
Changed Driver ran out of memory to Driver stack overflow as it currently shows duplicate entries in the webpage.
<img width="939" alt="image" src="https://github.com/holdenk/spark-flowchart/assets/3602551/9c951b11-09e1-46cb-9ea3-4b45a121e1f3">
